### PR TITLE
Changes to Wireless Paper V1.0 and V1.1

### DIFF
--- a/src/GxEPD2.h
+++ b/src/GxEPD2.h
@@ -44,8 +44,8 @@ class GxEPD2
       GDEH0213B72,  Waveshare_2_13_bw_B72 = GDEH0213B72,
       GDEH0213B73,  Waveshare_2_13_bw_B73 = GDEH0213B73,
       GDEM0213B74,  Waveshare_2_13_bw_B74 = GDEM0213B74,
-      DEPG0213BN,   // Heltec Wireless Paper v1.0, backported from GxEPD v1.5.5
-      GDEM0213FC1,
+      DEPG0213BN,       // Heltec Wireless Paper v1.0, backported from GxEPD v1.5.5
+      LCMEN2R13EFC1,    // Heltec Wireless Paper v1.1, custom
       GDEW0213I5F, Waveshare_2_13_flex = GDEW0213I5F,
       GDEW0213M21,
       GDEW0213T5D,

--- a/src/epd/GxEPD2_213_BN.cpp
+++ b/src/epd/GxEPD2_213_BN.cpp
@@ -351,12 +351,8 @@ void GxEPD2_213_BN::_InitDisplay()
   _writeData(0x00);
   _writeCommand(0x11); //data entry mode
   _writeData(0x03);
-  _writeCommand(0x3C); //BorderWavefrom
-  _writeData(0x05);
   _writeCommand(0x21); //  Display update control
   _writeData(0x00);
-  _writeData(0x80);
-  _writeCommand(0x18); //Read built-in temperature sensor
   _writeData(0x80);
   _setPartialRamArea(0, 0, WIDTH, HEIGHT);
   _using_partial_mode = false;
@@ -385,8 +381,24 @@ const unsigned char GxEPD2_213_BN::lut_partial[] PROGMEM =
   0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x0, 0x0, 0x0,
 };
 
+void GxEPD2_213_BN::_Init_Full()
+{
+  _InitDisplay();
+  _writeCommand(0x3C);  // Border Waveform
+  _writeData(0x05);
+  _writeCommand(0x18); //Read built-in temperature sensor
+  _writeData(0x80);
+  _using_partial_mode = false;
+}
+
+
 void GxEPD2_213_BN::_Init_Part()
 {
+  _InitDisplay();
+  _writeCommand(0x3C);  // Border Waveform
+  _writeData(0xC0);     // Floating (less noise-accumulation?)
+  _writeCommand(0x18); //Read built-in temperature sensor
+  _writeData(0x80);
   _writeCommand(0x32);
   _writeDataPGM(lut_partial, sizeof(lut_partial));
   _using_partial_mode = true;
@@ -394,7 +406,7 @@ void GxEPD2_213_BN::_Init_Part()
 
 void GxEPD2_213_BN::_Update_Full()
 {
-  _using_partial_mode = false;
+  if (_using_partial_mode) _Init_Full();
   _PowerOn();
   _writeCommand(0x22);
   _writeData(0xf4);

--- a/src/epd/GxEPD2_213_BN.h
+++ b/src/epd/GxEPD2_213_BN.h
@@ -35,7 +35,7 @@ class GxEPD2_213_BN : public GxEPD2_EPD
     static const bool hasFastPartialUpdate = true;
     static const uint16_t power_on_time = 100; // ms, e.g. 95868us
     static const uint16_t power_off_time = 250; // ms, e.g. 140350us
-    static const uint16_t full_refresh_time = 8100; // ms, e.g. 4011934us
+    static const uint16_t full_refresh_time = 4100; // ms, e.g. 4011934us
     static const uint16_t partial_refresh_time = 750; // ms, e.g. 736721us
     // constructor
     GxEPD2_213_BN(int16_t cs, int16_t dc, int16_t rst, int16_t busy, SPIClass &spi);

--- a/src/epd/GxEPD2_213_FC1.h
+++ b/src/epd/GxEPD2_213_FC1.h
@@ -1,15 +1,17 @@
-// Display Library for SPI e-paper panels from Dalian Good Display and boards from Waveshare.
-// Requires HW SPI and Adafruit_GFX. Caution: the e-paper panels require 3.3V supply AND data lines!
+// ##################################################################
+// #   Meshtastic: custom driver for Heltec Wireless Paper V1.1     #
+// ##################################################################
 //
-// based on Demo Example from Good Display, available here: http://www.e-paper-display.com/download_detail/downloadsId=806.html
-// Panel: GDEM0213B74 : https://www.good-display.com/product/375.html
-// Controller : SSD1680 : https://www.good-display.com/companyfile/101.html
+// From discussion: https://forum.arduino.cc/t/lcmen2r13efc1-discussion-heltec-wireless-paper/1211430
 //
-// Author: Jean-Marc Zingg
+// Panel: LCMEN2R13EFC1
+// Controller: JD79656 (undocumented as of 2024/02/18)
+// Board: Heltec Wireless Paper V1.1
 //
-// Version: see library.properties
-//
-// Library: https://github.com/ZinggJM/GxEPD2
+// --- NOTE! ---
+// This display is NOT officially supported by GxEPD2.
+// This fork is not affiliated with the original author.
+// This code is not intended for general use.
 
 #ifndef _GxEPD2_213_FC1_H_
 #define _GxEPD2_213_FC1_H_
@@ -23,61 +25,58 @@ class GxEPD2_213_FC1 : public GxEPD2_EPD
     static const uint16_t WIDTH = 128;
     static const uint16_t WIDTH_VISIBLE = 122;
     static const uint16_t HEIGHT = 250;
-    static const GxEPD2::Panel panel = GxEPD2::GDEM0213FC1;
+    static const GxEPD2::Panel panel = GxEPD2::LCMEN2R13EFC1;
     static const bool hasColor = false;
-    static const bool hasPartialUpdate = true;
-    static const bool hasFastPartialUpdate = false;
-    static const uint16_t power_on_time = 100; // ms, e.g. 95109us
-    static const uint16_t power_off_time = 150; // ms, e.g. 140344us
-    static const uint16_t full_refresh_time = 3600; // ms, e.g. 3501806us
-    static const uint16_t partial_refresh_time = 500; // ms, e.g. 455406us
+    static const bool hasPartialUpdate = true;  // Controller IC does not support partial update, but it *does* support fast refresh.
+    static const bool hasFastPartialUpdate = true;
+    static const uint16_t power_on_time = 0;   // Undetermined, unused
+    static const uint16_t power_off_time = 0;
+    static const uint16_t full_refresh_time = 0;
+    static const uint16_t partial_refresh_time = 0;
     // constructor
     GxEPD2_213_FC1(int16_t cs, int16_t dc, int16_t rst, int16_t busy, SPIClass &spi);
     // methods (virtual)
-    //  Support for Bitmaps (Sprites) to Controller Buffer and to Screen
     void clearScreen(uint8_t value = 0xFF); // init controller memory and screen (default white)
     void writeScreenBuffer(uint8_t value = 0xFF); // init controller memory (default white)
     // write to controller memory, without screen refresh; x and w should be multiple of 8
     void writeImage(const uint8_t bitmap[], int16_t x, int16_t y, int16_t w, int16_t h, bool invert = false, bool mirror_y = false, bool pgm = false);
-    void writeImagePart(const uint8_t bitmap[], int16_t x_part, int16_t y_part, int16_t w_bitmap, int16_t h_bitmap,
-                        int16_t x, int16_t y, int16_t w, int16_t h, bool invert = false, bool mirror_y = false, bool pgm = false);
-    void writeImage(const uint8_t* black, const uint8_t* color, int16_t x, int16_t y, int16_t w, int16_t h, bool invert = false, bool mirror_y = false, bool pgm = false);
-    void writeImagePart(const uint8_t* black, const uint8_t* color, int16_t x_part, int16_t y_part, int16_t w_bitmap, int16_t h_bitmap,
-                        int16_t x, int16_t y, int16_t w, int16_t h, bool invert = false, bool mirror_y = false, bool pgm = false);
-    // write sprite of native data to controller memory, without screen refresh; x and w should be multiple of 8
-    void writeNative(const uint8_t* data1, const uint8_t* data2, int16_t x, int16_t y, int16_t w, int16_t h, bool invert = false, bool mirror_y = false, bool pgm = false);
-    // write to controller memory, with screen refresh; x and w should be multiple of 8
-    void drawImage(const uint8_t bitmap[], int16_t x, int16_t y, int16_t w, int16_t h, bool invert = false, bool mirror_y = false, bool pgm = false);
-    void drawImagePart(const uint8_t bitmap[], int16_t x_part, int16_t y_part, int16_t w_bitmap, int16_t h_bitmap,
-                       int16_t x, int16_t y, int16_t w, int16_t h, bool invert = false, bool mirror_y = false, bool pgm = false);
-    void drawImage(const uint8_t* black, const uint8_t* color, int16_t x, int16_t y, int16_t w, int16_t h, bool invert = false, bool mirror_y = false, bool pgm = false);
-    void drawImagePart(const uint8_t* black, const uint8_t* color, int16_t x_part, int16_t y_part, int16_t w_bitmap, int16_t h_bitmap,
-                       int16_t x, int16_t y, int16_t w, int16_t h, bool invert = false, bool mirror_y = false, bool pgm = false);
-    // write sprite of native data to controller memory, with screen refresh; x and w should be multiple of 8
-    void drawNative(const uint8_t* data1, const uint8_t* data2, int16_t x, int16_t y, int16_t w, int16_t h, bool invert = false, bool mirror_y = false, bool pgm = false);
+    void writeImageAgain(const uint8_t bitmap[], int16_t x, int16_t y, int16_t w, int16_t h, bool invert = false, bool mirror_y = false, bool pgm = false);
     void refresh(bool partial_update_mode = false); // screen refresh from controller memory to full screen
-    void refresh(int16_t x, int16_t y, int16_t w, int16_t h); // screen refresh from controller memory, partial screen
+    void refresh(int16_t x, int16_t y, int16_t w, int16_t h); // screen refresh from controller memory, fast-refresh
     void powerOff(); // turns off generation of panel driving voltages, avoids screen fading over time
     void hibernate(); // turns powerOff() and sets controller to deep sleep for minimum power use, ONLY if wakeable by RST (rst >= 0)
+
+  // Unimplemented for meshtastic
+  public:
+    void writeImagePart(const uint8_t bitmap[], int16_t x_part, int16_t y_part, int16_t w_bitmap, int16_t h_bitmap,
+                          int16_t x, int16_t y, int16_t w, int16_t h, bool invert = false, bool mirror_y = false, bool pgm = false) {}
+    void drawImage(const uint8_t bitmap[], int16_t x, int16_t y, int16_t w, int16_t h, bool invert = false, bool mirror_y = false, bool pgm = false) {}
+    void drawImagePart(const uint8_t bitmap[], int16_t x_part, int16_t y_part, int16_t w_bitmap, int16_t h_bitmap,
+                        int16_t x, int16_t y, int16_t w, int16_t h, bool invert = false, bool mirror_y = false, bool pgm = false) {}
+    void _setPartialRamArea(uint16_t x, uint16_t y, uint16_t w, uint16_t h) {}  // (Normally private, moved here only so it is with the other unimplemented methods)
+
   private:
     void _writeScreenBuffer(uint8_t command, uint8_t value);
     void _writeImage(uint8_t command, const uint8_t bitmap[], int16_t x, int16_t y, int16_t w, int16_t h, bool invert = false, bool mirror_y = false, bool pgm = false);
     void _writeImagePart(uint8_t command, const uint8_t bitmap[], int16_t x_part, int16_t y_part, int16_t w_bitmap, int16_t h_bitmap,
                          int16_t x, int16_t y, int16_t w, int16_t h, bool invert = false, bool mirror_y = false, bool pgm = false);
-    void _setPartialRamArea(uint16_t x, uint16_t y, uint16_t w, uint16_t h);
+    void _reset(); // Custom, uses _waitWhileBusy() instead of delay()
+    void _Wake();
     void _PowerOn();
     void _PowerOff();
-    void _InitDisplay();
     void _Init_Full();
     void _Init_Part();
     void _Update_Full();
     void _Update_Part();
+
   private:
-    static const unsigned char lut_20_vcomDC_partial[];
-    static const unsigned char lut_21_ww_partial[];
-    static const unsigned char lut_22_bw_partial[];
-    static const unsigned char lut_23_wb_partial[];
-    static const unsigned char lut_24_bb_partial[];
+    bool _configured_for_fast = false;
+    bool _configured_for_full = false;
+    static const unsigned char lut_20_vcomDC_partial[56];
+    static const unsigned char lut_21_ww_partial[56];
+    static const unsigned char lut_22_bw_partial[56];
+    static const unsigned char lut_23_wb_partial[56];
+    static const unsigned char lut_24_bb_partial[56];
 };
 
 #endif


### PR DESCRIPTION
 #### DEPG0213BNS800 - Heltec Wireless Paper V1.0
  - Implement a missing soft-reset when swapping between fast and full refresh.
  - Change border waveform used for fast refresh.

#### LCMEN2R13EFC1 - Heltec Wireless Paper V1.1
  - Rewritten, modeled on another class which has same limitation as LCMEN2R13EFC1 (no support for "partial window").
  - Fast refresh implemented, using custom LUT.

Note: Changes to LCMEN2R13EFC1 will not immediately impact meshtastic/firmware. A further pull-request is required to point lib_deps back at this repo.