### PR TITLE
Async Full Refresh

### DIFF
--- a/src/GxEPD2_EPD.cpp
+++ b/src/GxEPD2_EPD.cpp
@@ -255,11 +255,6 @@ bool GxEPD2_EPD::isBusy() {
 
 // Used to skip _waitWhileBusy(), for meshtastic async
 bool GxEPD2_EPD::_isUpdatingFull(const char* comment) {
-  // On first update, a fast-refresh might also clear screen using a full-refresh
-  // If meshtastic/firmware asked for fast-refresh, it will expect this full-refresh to block. So: force that to happen
-  if (_initial_refresh)
-    return false;
-
   // True if comment matches
   return ( strcmp(comment, "_Update_Full") == 0 );
 }

--- a/src/GxEPD2_EPD.cpp
+++ b/src/GxEPD2_EPD.cpp
@@ -96,6 +96,10 @@ void GxEPD2_EPD::_reset()
 
 void GxEPD2_EPD::_waitWhileBusy(const char* comment, uint16_t busy_time)
 {
+  // For full refreshes, meshtastic/firmare will poll GxEPD2_EPD::isBusy() instead of waiting here
+  if (_isUpdatingFull(comment))
+    return;
+
   if (_busy >= 0)
   {
     delay(1); // add some margin to become active
@@ -240,4 +244,20 @@ void GxEPD2_EPD::_endTransfer()
 {
   if (_cs >= 0) digitalWrite(_cs, HIGH);
   _spi.endTransaction();
+}
+
+// Polled by meshtastic/firmware, during async full-refresh
+bool GxEPD2_EPD::isBusy() {
+  return (digitalRead(_busy) == _busy_level);
+}
+
+// Used to skip _waitWhileBusy(), for meshtastic async
+bool GxEPD2_EPD::_isUpdatingFull(const char* comment) {
+  // On first update, a fast-refresh might also clear screen using a full-refresh
+  // If meshtastic/firmware asked for fast-refresh, it will expect this full-refresh to block. So: force that to happen
+  if (_initial_refresh)
+    return false;
+
+  // True if comment matches
+  return ( strcmp(comment, "_Update_Full") == 0 );
 }

--- a/src/GxEPD2_EPD.cpp
+++ b/src/GxEPD2_EPD.cpp
@@ -96,9 +96,11 @@ void GxEPD2_EPD::_reset()
 
 void GxEPD2_EPD::_waitWhileBusy(const char* comment, uint16_t busy_time)
 {
-  // For full refreshes, meshtastic/firmare will poll GxEPD2_EPD::isBusy() instead of waiting here
+  // For full refreshes, meshtastic/firmare will poll GxEPD2_EPD::isBusy() instead of waiting here (for EInkDynamicDisplay only)
+#if defined(USE_EINK_DYNAMICDISPLAY)
   if (_isUpdatingFull(comment))
     return;
+#endif
 
   if (_busy >= 0)
   {

--- a/src/GxEPD2_EPD.h
+++ b/src/GxEPD2_EPD.h
@@ -91,6 +91,7 @@ class GxEPD2_EPD
     {
       return (a > b ? a : b);
     };
+    bool isBusy();  // Used in meshtastic/firmware, to poll after nextPage(), for async full refresh
   protected:
     void _reset();
     void _waitWhileBusy(const char* comment = 0, uint16_t busy_time = 5000);
@@ -104,6 +105,7 @@ class GxEPD2_EPD
     void _startTransfer();
     void _transfer(uint8_t value);
     void _endTransfer();
+    bool _isUpdatingFull(const char* comment);  // Meshtastic: Determine if _waitWhileBusy() should be skipped (for async), by comparing the comment string..
   protected:
     int8_t _cs, _dc, _rst, _busy, _busy_level;
     uint32_t _busy_timeout;

--- a/src/epd/GxEPD2_213_FC1.cpp
+++ b/src/epd/GxEPD2_213_FC1.cpp
@@ -38,6 +38,7 @@ void GxEPD2_213_FC1::clearScreen(uint8_t value)
   _writeScreenBuffer(0x13, value); // Clear "NEW" (red) mem
   _writeScreenBuffer(0x10, value); // Clear "OLD" (black) mem
   refresh(false); // Full refresh
+  _PowerOff();
   _initial_write = false;
   _initial_refresh = false;
 }

--- a/src/epd/GxEPD2_213_FC1.cpp
+++ b/src/epd/GxEPD2_213_FC1.cpp
@@ -158,19 +158,10 @@ void GxEPD2_213_FC1::powerOff()
   _PowerOff();
 }
 
-// Put the display into an extra-low power state. Hard reset required to wake.
-// Caution: will wipe display memory - problematic for fast-refresh, so not used by meshtastic
+// No hibernate for this display, only power off. Preserves image memory for fast refresh.
 void GxEPD2_213_FC1::hibernate()
 {
   _PowerOff();
-  if (_rst >= 0)
-  {
-    _writeCommand(0x07); // deep sleep mode
-    _writeData(0xA5);     // enter deep sleep
-    _hibernating = true;
-    _configured_for_full = false;
-    _configured_for_fast = false;
-  }
 }
 
 void GxEPD2_213_FC1::_PowerOn()
@@ -280,7 +271,6 @@ void GxEPD2_213_FC1::_Update_Full()
   _PowerOn();
   _writeCommand(0x12);
   _waitWhileBusy("_Update_Full", full_refresh_time);
-  _PowerOff();
 }
 
 void GxEPD2_213_FC1::_Update_Part()
@@ -289,7 +279,6 @@ void GxEPD2_213_FC1::_Update_Part()
   _PowerOn();
   _writeCommand(0x12);
   _waitWhileBusy("_Update_Part", partial_refresh_time);
-  _PowerOff();
 }
 
 // Fast refresh waveform is unofficial (experimental?)

--- a/src/epd/GxEPD2_213_FC1.h
+++ b/src/epd/GxEPD2_213_FC1.h
@@ -44,7 +44,7 @@ class GxEPD2_213_FC1 : public GxEPD2_EPD
     void refresh(bool partial_update_mode = false); // screen refresh from controller memory to full screen
     void refresh(int16_t x, int16_t y, int16_t w, int16_t h); // screen refresh from controller memory, fast-refresh
     void powerOff(); // turns off generation of panel driving voltages, avoids screen fading over time
-    void hibernate(); // turns powerOff() and sets controller to deep sleep for minimum power use, ONLY if wakeable by RST (rst >= 0)
+    void hibernate(); // For this display, no deep sleep, only power off. Preserves image memory for fast refresh
 
   // Unimplemented for meshtastic
   public:


### PR DESCRIPTION
Makes changes necessary for https://github.com/meshtastic/firmware/pull/3339

`GxEPD2_BW::nextPage()` has been modified so that full-refresh optionally bypasses `GxEPD2_EPD::_waitWhileBusy()`, and skips the remaining nextPage() code.

When relevant, meshtastic/firmware polls `GxEPD2_EPD::isBusy()`, and then calls `GxEPD2_BW::endAsyncFull()`, running the remaining nextPage() code which was bypassed earlier. 