### PR TITLE
Fix fast-refresh ghosting on Heltec Vision Master E290 (GxEPD2_290_BN8)

### DIFF
--- a/src/epd/GxEPD2_290_BN8.cpp
+++ b/src/epd/GxEPD2_290_BN8.cpp
@@ -109,11 +109,16 @@ void GxEPD2_290_BN8::writeImage(const uint8_t bitmap[], int16_t x, int16_t y, in
     _writeImage(0x24, bitmap, x, y, w, h, invert, mirror_y, pgm);
 }
 
-// Write image to "OLD" (black) memory. Used for determining which pixels move during fast refresh
+// Write image to both NEW and OLD memory after fast refresh, keeping both buffers in sync so the
+// controller's differential refresh compares against the image that's actually on screen (E290
+// fast-refresh ghosting fix: writing only to OLD left NEW stale, causing incorrect pixel diffs)
 void GxEPD2_290_BN8::writeImageAgain(const uint8_t bitmap[], int16_t x, int16_t y, int16_t w, int16_t h, bool invert,
                                      bool mirror_y, bool pgm)
 {
-    // Pass-down to the generic write method method, passing the command for write "OLD" mem
+    // Write to NEW memory first (required for proper differential refresh)
+    _writeImage(0x24, bitmap, x, y, w, h, invert, mirror_y, pgm);
+
+    // Then write to OLD memory
     _writeImage(0x26, bitmap, x, y, w, h, invert, mirror_y, pgm);
 
     // Tell the display controller IC that we're done transferring image data, but don't want to take further action


### PR DESCRIPTION
## Problem

The `GxEPD2_290_BN8` driver (used by Meshtastic's Heltec Vision Master E290 build) shows significant ghosting during fast (partial) refresh.

## Root cause

`writeImageAgain()` only wrote the outgoing frame to the controller's OLD memory buffer (0x26), leaving NEW memory (0x24) stale after each fast refresh. The SSD1680 controller's differential refresh compares NEW against OLD to decide which pixels changed and which waveform to apply. With NEW left stale, the controller made incorrect pixel-diff decisions on the next refresh, producing ghosting.

## Fix

`writeImageAgain()` now writes the same bitmap to both NEW (0x24) and OLD (0x26) memory, keeping both buffers in sync with what's actually on screen — mirroring how `finalizeUpdate()` already handles this in Meshtastic's InkHUD driver stack.

## Testing

Built and flashed onto a physical Heltec Vision Master E290 running Meshtastic firmware (`heltec-vision-master-e290` env), navigating repeatedly through menus/screens that previously showed heavy ghosting on fast refresh. Ghosting is much improved after the fix.

## Credit

Root cause and fix originally identified by kuroanji: https://github.com/kuroanji/Heltec_VME290_Hybrid_Driver (see `gxepd2-e290-ghosting-fix/README.md` in that repo for the original writeup).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved fast-refresh behavior on supported displays so updated content stays in sync across refreshes.
  - Reduced ghosting and visual artifacts by keeping display buffers aligned after repeated image updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->